### PR TITLE
Fix Sentry reporting

### DIFF
--- a/server.rb
+++ b/server.rb
@@ -10,6 +10,8 @@ Clamby.configure(
   error_file_virus: false
 )
 
+Sentry.init { |config| config.dsn = ENV['SENTRY_DSN'] }
+
 use Sentry::Rack::CaptureExceptions
 
 set :bind, '0.0.0.0'


### PR DESCRIPTION
It appears that contrary to the docs, the Sentry DSN needs to be explicitly set rather than being picked up automatically via the `SENTRY_DSN` environment variable.

Tested that messages are now coming through when running the Docker image locally.

We'll probably need to modify this further to avoid exceptions being reported during health checks on the `/health` endpoint while ClamAV is starting, but we'll need to implement the CloudFoundry health check first and check which exceptions we want to ignore.