### PR TITLE
Use rolling deployments. Fixes 404 errors when the app is deploying.

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -10,4 +10,4 @@ set -ex
 # SPACE: the space to which you want to deploy
 # BUILD_ID: the docker tag that you want to deploy
 
-cf push -f ./$MANIFEST --docker-image beisopss/antivirus:$BUILD_ID --var hostname=antivirus-$SPACE.london.cloudapps.digital
+cf push -f ./$MANIFEST --docker-image beisopss/antivirus:$BUILD_ID --var hostname=antivirus-$SPACE.london.cloudapps.digital --strategy rolling


### PR DESCRIPTION
Implements the rolling deployment strategy to avoid interruption to clients by receiving 404 errors while the new version is deploying.

This does not fix the 500 errors which are caused by the ClamAV process not being ready. This should be possible to fix using HTTP health checks, which will be worked on separately.