### PR TITLE
Implement HTTP endpoint health check

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,11 +27,6 @@ This will configure sinatra to run in production mode.
     cf set-env antivirus ANTIVIRUS_USERNAME XXX
     cf set-env antivirus ANTIVIRUS_PASSWORD XXX
 
-This will set HTTP basic auth for the API.
-
-    cf set-env antivirus HEALTH_USERNAME XXX
-    cf set-env antivirus HEALTH_PASSWORD XXX
-
 This will set the Sentry configuration
 
     cf set-env antivirus SENTRY_DSN XXX

--- a/manifest.review.yml
+++ b/manifest.review.yml
@@ -9,3 +9,5 @@ applications:
   disk_quota: 2G
   services:
     - opss-log-drain
+  health-check-type: http
+  health-check-http-endpoint: /health

--- a/manifest.yml
+++ b/manifest.yml
@@ -9,3 +9,5 @@ applications:
   disk_quota: 2G
   services:
     - opss-log-drain
+  health-check-type: http
+  health-check-http-endpoint: /health

--- a/server.rb
+++ b/server.rb
@@ -43,8 +43,6 @@ post '/safe' do
 end
 
 get '/health' do
-  protect!(ENV['HEALTH_USERNAME'], ENV['HEALTH_PASSWORD'])
-
   content_type :json
 
   status Clamby.safe?('./server.rb') ? 200 : 500


### PR DESCRIPTION
Implements HTTP health checks.

This should allow the GOV.UK PaaS service to know when the antivirus service is healthy when performing a rolling deployment or after deployed.

The health checks do not appear to support HTTP basic auth so I have had to remove authentication on the `/health` endpoint.

This resolves an issue we had last night where one of the antivirus service instances was unhealthy and throwing 500 errors. It also resolves 500 errors that are thrown when the app is being deployed and the ClamAV process is not yet ready.

## ⚠️ Before deployment

I've tested that this works with a standard, non-rolling deployment by checking the `/health` endpoint during the deployment and not receiving any 500 errors. Once #13 is merged we should test again.

The `/health` endpoint is likely to throw exceptions during deployment while the ClamAV process is starting. When #12 is merged we will need to test the exceptions which are expected to be thrown and silence them, otherwise we will start receiving Sentry alerts.

We might need to increase the timeout in the manifest as the default 1 minute may be insufficient for all instances in production to become healthy.