### PR TITLE
Silence Sentry reporting on health check endpoint

### DIFF
--- a/server.rb
+++ b/server.rb
@@ -45,5 +45,13 @@ end
 get '/health' do
   content_type :json
 
-  status Clamby.safe?('./server.rb') ? 200 : 500
+  begin
+    status Clamby.safe?('./server.rb') ? 200 : 500
+
+  # The ClamAV process takes a bit longer to start than the Sinatra process.
+  # We can safely prevent Sentry capturing these exceptions but allow the
+  # CloudFoundry health check to see the app is not healthy
+  rescue Clamby::ClamscanClientError
+    status 500
+  end
 end


### PR DESCRIPTION
When the application is deploying the CloudFoundry health check will poll the `/health` endpoint every two seconds. During this time we expect to see exception raised until the ClamAV process has fully started.

This change captures those exceptions so they're not reported to Sentry, but still returns a 500 status code to the health checker so it can act accordingly.

See #14 for more background.